### PR TITLE
Re-wrote client; other networking changes

### DIFF
--- a/Science/Science Base/MainWindow.Designer.cs
+++ b/Science/Science Base/MainWindow.Designer.cs
@@ -42,7 +42,6 @@
             this.IDTextbox = new DarkUI.Controls.DarkTextBox();
             this.DataTextbox = new DarkUI.Controls.DarkTextBox();
             this.DataTitle = new DarkUI.Controls.DarkLabel();
-            this.SendPacketBtn = new DarkUI.Controls.DarkButton();
             this.tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
             this.UseCurrentTime = new DarkUI.Controls.DarkCheckBox();
             this.TimestampTextbox = new DarkUI.Controls.DarkTextBox();
@@ -50,6 +49,9 @@
             this.InterpretationID = new DarkUI.Controls.DarkLabel();
             this.InterpretationData = new DarkUI.Controls.DarkLabel();
             this.PacketConstructStatus = new DarkUI.Controls.DarkLabel();
+            this.tableLayoutPanel3 = new System.Windows.Forms.TableLayoutPanel();
+            this.SendPacketBtn = new DarkUI.Controls.DarkButton();
+            this.ClientSelector = new System.Windows.Forms.ComboBox();
             this.groupBox1 = new System.Windows.Forms.GroupBox();
             this.tableLayoutPanel4 = new System.Windows.Forms.TableLayoutPanel();
             this.StatsPacketQueueOut = new DarkUI.Controls.DarkLabel();
@@ -57,8 +59,7 @@
             this.EmergencyStopBtn = new System.Windows.Forms.Button();
             this.SecTimer = new System.Windows.Forms.Timer(this.components);
             this.UIUpdate = new System.Windows.Forms.Timer(this.components);
-            this.tableLayoutPanel3 = new System.Windows.Forms.TableLayoutPanel();
-            this.ClientSelector = new System.Windows.Forms.ComboBox();
+            this.SendAsUDP = new System.Windows.Forms.CheckBox();
             this.tableLayoutPanel1.SuspendLayout();
             this.tabControl1.SuspendLayout();
             this.Debugging.SuspendLayout();
@@ -66,9 +67,9 @@
             this.PacketGenBox.SuspendLayout();
             this.PacketGenLayout.SuspendLayout();
             this.tableLayoutPanel2.SuspendLayout();
+            this.tableLayoutPanel3.SuspendLayout();
             this.groupBox1.SuspendLayout();
             this.tableLayoutPanel4.SuspendLayout();
-            this.tableLayoutPanel3.SuspendLayout();
             this.SuspendLayout();
             // 
             // tableLayoutPanel1
@@ -165,7 +166,7 @@
             this.PacketGenLayout.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 20F));
             this.PacketGenLayout.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 15F));
             this.PacketGenLayout.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 65F));
-            this.PacketGenLayout.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 150F));
+            this.PacketGenLayout.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 151F));
             this.PacketGenLayout.Controls.Add(this.TimestampTitle, 0, 0);
             this.PacketGenLayout.Controls.Add(this.IDTitle, 1, 0);
             this.PacketGenLayout.Controls.Add(this.IDTextbox, 1, 1);
@@ -177,6 +178,7 @@
             this.PacketGenLayout.Controls.Add(this.InterpretationData, 2, 2);
             this.PacketGenLayout.Controls.Add(this.PacketConstructStatus, 3, 2);
             this.PacketGenLayout.Controls.Add(this.tableLayoutPanel3, 3, 1);
+            this.PacketGenLayout.Controls.Add(this.SendAsUDP, 3, 0);
             this.PacketGenLayout.Dock = System.Windows.Forms.DockStyle.Fill;
             this.PacketGenLayout.Location = new System.Drawing.Point(3, 16);
             this.PacketGenLayout.Margin = new System.Windows.Forms.Padding(0);
@@ -195,7 +197,7 @@
             this.TimestampTitle.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
             this.TimestampTitle.Location = new System.Drawing.Point(3, 0);
             this.TimestampTitle.Name = "TimestampTitle";
-            this.TimestampTitle.Size = new System.Drawing.Size(116, 13);
+            this.TimestampTitle.Size = new System.Drawing.Size(115, 17);
             this.TimestampTitle.TabIndex = 0;
             this.TimestampTitle.Text = "Timestamp";
             // 
@@ -204,9 +206,9 @@
             this.IDTitle.AutoSize = true;
             this.IDTitle.Dock = System.Windows.Forms.DockStyle.Fill;
             this.IDTitle.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.IDTitle.Location = new System.Drawing.Point(125, 0);
+            this.IDTitle.Location = new System.Drawing.Point(124, 0);
             this.IDTitle.Name = "IDTitle";
-            this.IDTitle.Size = new System.Drawing.Size(85, 13);
+            this.IDTitle.Size = new System.Drawing.Size(85, 17);
             this.IDTitle.TabIndex = 2;
             this.IDTitle.Text = "ID";
             // 
@@ -217,7 +219,7 @@
             this.IDTextbox.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
             this.IDTextbox.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.IDTextbox.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.IDTextbox.Location = new System.Drawing.Point(125, 16);
+            this.IDTextbox.Location = new System.Drawing.Point(124, 20);
             this.IDTextbox.Name = "IDTextbox";
             this.IDTextbox.Size = new System.Drawing.Size(85, 20);
             this.IDTextbox.TabIndex = 3;
@@ -230,9 +232,9 @@
             this.DataTextbox.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(69)))), ((int)(((byte)(73)))), ((int)(((byte)(74)))));
             this.DataTextbox.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.DataTextbox.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.DataTextbox.Location = new System.Drawing.Point(216, 16);
+            this.DataTextbox.Location = new System.Drawing.Point(215, 20);
             this.DataTextbox.Name = "DataTextbox";
-            this.DataTextbox.Size = new System.Drawing.Size(390, 20);
+            this.DataTextbox.Size = new System.Drawing.Size(389, 20);
             this.DataTextbox.TabIndex = 4;
             this.DataTextbox.TextChanged += new System.EventHandler(this.DataTextbox_TextChanged);
             // 
@@ -241,23 +243,11 @@
             this.DataTitle.AutoSize = true;
             this.DataTitle.Dock = System.Windows.Forms.DockStyle.Fill;
             this.DataTitle.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.DataTitle.Location = new System.Drawing.Point(216, 0);
+            this.DataTitle.Location = new System.Drawing.Point(215, 0);
             this.DataTitle.Name = "DataTitle";
-            this.DataTitle.Size = new System.Drawing.Size(390, 13);
+            this.DataTitle.Size = new System.Drawing.Size(389, 17);
             this.DataTitle.TabIndex = 5;
             this.DataTitle.Text = "Data";
-            // 
-            // SendPacketBtn
-            // 
-            this.SendPacketBtn.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.SendPacketBtn.Location = new System.Drawing.Point(3, 37);
-            this.SendPacketBtn.Name = "SendPacketBtn";
-            this.SendPacketBtn.Padding = new System.Windows.Forms.Padding(5);
-            this.SendPacketBtn.Size = new System.Drawing.Size(145, 25);
-            this.SendPacketBtn.TabIndex = 5;
-            this.SendPacketBtn.Text = "Send";
-            this.SendPacketBtn.Click += new System.EventHandler(this.SendPacketBtn_Click);
             // 
             // tableLayoutPanel2
             // 
@@ -266,13 +256,13 @@
             this.tableLayoutPanel2.Controls.Add(this.UseCurrentTime, 0, 1);
             this.tableLayoutPanel2.Controls.Add(this.TimestampTextbox, 0, 0);
             this.tableLayoutPanel2.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel2.Location = new System.Drawing.Point(0, 13);
+            this.tableLayoutPanel2.Location = new System.Drawing.Point(0, 17);
             this.tableLayoutPanel2.Margin = new System.Windows.Forms.Padding(0);
             this.tableLayoutPanel2.Name = "tableLayoutPanel2";
             this.tableLayoutPanel2.RowCount = 2;
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel2.Size = new System.Drawing.Size(122, 69);
+            this.tableLayoutPanel2.Size = new System.Drawing.Size(121, 65);
             this.tableLayoutPanel2.TabIndex = 7;
             // 
             // UseCurrentTime
@@ -294,7 +284,7 @@
             this.TimestampTextbox.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
             this.TimestampTextbox.Location = new System.Drawing.Point(3, 3);
             this.TimestampTextbox.Name = "TimestampTextbox";
-            this.TimestampTextbox.Size = new System.Drawing.Size(116, 20);
+            this.TimestampTextbox.Size = new System.Drawing.Size(115, 20);
             this.TimestampTextbox.TabIndex = 2;
             this.TimestampTextbox.TextChanged += new System.EventHandler(this.TimestampTextbox_TextChanged);
             // 
@@ -305,7 +295,7 @@
             this.InterpretationTimestamp.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
             this.InterpretationTimestamp.Location = new System.Drawing.Point(3, 82);
             this.InterpretationTimestamp.Name = "InterpretationTimestamp";
-            this.InterpretationTimestamp.Size = new System.Drawing.Size(116, 13);
+            this.InterpretationTimestamp.Size = new System.Drawing.Size(115, 13);
             this.InterpretationTimestamp.TabIndex = 8;
             this.InterpretationTimestamp.Text = "Unknown";
             // 
@@ -314,7 +304,7 @@
             this.InterpretationID.AutoSize = true;
             this.InterpretationID.Dock = System.Windows.Forms.DockStyle.Fill;
             this.InterpretationID.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.InterpretationID.Location = new System.Drawing.Point(125, 82);
+            this.InterpretationID.Location = new System.Drawing.Point(124, 82);
             this.InterpretationID.Name = "InterpretationID";
             this.InterpretationID.Size = new System.Drawing.Size(85, 13);
             this.InterpretationID.TabIndex = 9;
@@ -325,9 +315,9 @@
             this.InterpretationData.AutoSize = true;
             this.InterpretationData.Dock = System.Windows.Forms.DockStyle.Fill;
             this.InterpretationData.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.InterpretationData.Location = new System.Drawing.Point(216, 82);
+            this.InterpretationData.Location = new System.Drawing.Point(215, 82);
             this.InterpretationData.Name = "InterpretationData";
-            this.InterpretationData.Size = new System.Drawing.Size(390, 13);
+            this.InterpretationData.Size = new System.Drawing.Size(389, 13);
             this.InterpretationData.TabIndex = 10;
             this.InterpretationData.Text = "Unknown";
             // 
@@ -336,11 +326,50 @@
             this.PacketConstructStatus.AutoSize = true;
             this.PacketConstructStatus.Dock = System.Windows.Forms.DockStyle.Fill;
             this.PacketConstructStatus.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(220)))), ((int)(((byte)(220)))), ((int)(((byte)(220)))));
-            this.PacketConstructStatus.Location = new System.Drawing.Point(612, 82);
+            this.PacketConstructStatus.Location = new System.Drawing.Point(610, 82);
             this.PacketConstructStatus.Name = "PacketConstructStatus";
-            this.PacketConstructStatus.Size = new System.Drawing.Size(145, 13);
+            this.PacketConstructStatus.Size = new System.Drawing.Size(147, 13);
             this.PacketConstructStatus.TabIndex = 11;
             this.PacketConstructStatus.Text = "Unknown";
+            // 
+            // tableLayoutPanel3
+            // 
+            this.tableLayoutPanel3.ColumnCount = 1;
+            this.tableLayoutPanel3.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanel3.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 20F));
+            this.tableLayoutPanel3.Controls.Add(this.SendPacketBtn, 0, 1);
+            this.tableLayoutPanel3.Controls.Add(this.ClientSelector, 0, 0);
+            this.tableLayoutPanel3.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tableLayoutPanel3.Location = new System.Drawing.Point(607, 17);
+            this.tableLayoutPanel3.Margin = new System.Windows.Forms.Padding(0);
+            this.tableLayoutPanel3.Name = "tableLayoutPanel3";
+            this.tableLayoutPanel3.RowCount = 2;
+            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
+            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
+            this.tableLayoutPanel3.Size = new System.Drawing.Size(153, 65);
+            this.tableLayoutPanel3.TabIndex = 12;
+            // 
+            // SendPacketBtn
+            // 
+            this.SendPacketBtn.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.SendPacketBtn.Location = new System.Drawing.Point(3, 35);
+            this.SendPacketBtn.Name = "SendPacketBtn";
+            this.SendPacketBtn.Padding = new System.Windows.Forms.Padding(5);
+            this.SendPacketBtn.Size = new System.Drawing.Size(147, 25);
+            this.SendPacketBtn.TabIndex = 5;
+            this.SendPacketBtn.Text = "Send";
+            this.SendPacketBtn.Click += new System.EventHandler(this.SendPacketBtn_Click);
+            // 
+            // ClientSelector
+            // 
+            this.ClientSelector.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.ClientSelector.FormattingEnabled = true;
+            this.ClientSelector.Location = new System.Drawing.Point(3, 3);
+            this.ClientSelector.Name = "ClientSelector";
+            this.ClientSelector.Size = new System.Drawing.Size(147, 21);
+            this.ClientSelector.TabIndex = 6;
             // 
             // groupBox1
             // 
@@ -424,32 +453,18 @@
             this.UIUpdate.Interval = 33;
             this.UIUpdate.Tick += new System.EventHandler(this.UIUpdate_Tick);
             // 
-            // tableLayoutPanel3
+            // SendAsUDP
             // 
-            this.tableLayoutPanel3.ColumnCount = 1;
-            this.tableLayoutPanel3.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel3.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 20F));
-            this.tableLayoutPanel3.Controls.Add(this.SendPacketBtn, 0, 1);
-            this.tableLayoutPanel3.Controls.Add(this.ClientSelector, 0, 0);
-            this.tableLayoutPanel3.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel3.Location = new System.Drawing.Point(609, 13);
-            this.tableLayoutPanel3.Margin = new System.Windows.Forms.Padding(0);
-            this.tableLayoutPanel3.Name = "tableLayoutPanel3";
-            this.tableLayoutPanel3.RowCount = 2;
-            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
-            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
-            this.tableLayoutPanel3.Size = new System.Drawing.Size(151, 69);
-            this.tableLayoutPanel3.TabIndex = 12;
-            // 
-            // ClientSelector
-            // 
-            this.ClientSelector.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.ClientSelector.FormattingEnabled = true;
-            this.ClientSelector.Location = new System.Drawing.Point(3, 3);
-            this.ClientSelector.Name = "ClientSelector";
-            this.ClientSelector.Size = new System.Drawing.Size(145, 21);
-            this.ClientSelector.TabIndex = 6;
+            this.SendAsUDP.AutoSize = true;
+            this.SendAsUDP.Checked = true;
+            this.SendAsUDP.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.SendAsUDP.Location = new System.Drawing.Point(610, 0);
+            this.SendAsUDP.Margin = new System.Windows.Forms.Padding(3, 0, 0, 0);
+            this.SendAsUDP.Name = "SendAsUDP";
+            this.SendAsUDP.Size = new System.Drawing.Size(49, 17);
+            this.SendAsUDP.TabIndex = 13;
+            this.SendAsUDP.Text = "UDP";
+            this.SendAsUDP.UseVisualStyleBackColor = true;
             // 
             // MainWindow
             // 
@@ -471,10 +486,10 @@
             this.PacketGenLayout.PerformLayout();
             this.tableLayoutPanel2.ResumeLayout(false);
             this.tableLayoutPanel2.PerformLayout();
+            this.tableLayoutPanel3.ResumeLayout(false);
             this.groupBox1.ResumeLayout(false);
             this.tableLayoutPanel4.ResumeLayout(false);
             this.tableLayoutPanel4.PerformLayout();
-            this.tableLayoutPanel3.ResumeLayout(false);
             this.ResumeLayout(false);
 
         }
@@ -510,5 +525,6 @@
         private DarkUI.Controls.DarkLabel StatsPacketQueueIn;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel3;
         private System.Windows.Forms.ComboBox ClientSelector;
+        private System.Windows.Forms.CheckBox SendAsUDP;
     }
 }

--- a/Science/Science Base/MainWindow.cs
+++ b/Science/Science Base/MainWindow.cs
@@ -39,14 +39,17 @@ namespace Science_Base
         {
             try
             {
-                byte[] Timestamp = UtilMain.StringToBytes(this.TimestampTextbox.Text).Reverse().ToArray();
-                byte ID = UtilMain.StringToBytes(this.IDTextbox.Text)[0];
-                byte[] Data = InterpretInput(this.DataTextbox.Text.ToCharArray());
-                Packet Pack = new Packet(ID, false, ClientSelector.Items[0].ToString());
-                Log.Output(Log.Severity.DEBUG, Log.Source.NETWORK, "Sending packet with data length: " + Data.Length);
-                Pack.AppendData(Data);
-                Server.Send(Pack);
-                Log.Output(Log.Severity.INFO, Log.Source.GUI, "Sending custom packet: " + Pack.ToString());
+                for(int i = 0; i < 100; i++)
+                {
+                    byte[] Timestamp = UtilMain.StringToBytes(this.TimestampTextbox.Text).Reverse().ToArray();
+                    byte ID = UtilMain.StringToBytes(this.IDTextbox.Text)[0];
+                    byte[] Data = InterpretInput(this.DataTextbox.Text.ToCharArray());
+                    Packet Pack = new Packet(ID, this.SendAsUDP.Checked, this.ClientSelector.SelectedItem.ToString());
+                    Log.Output(Log.Severity.DEBUG, Log.Source.NETWORK, "Sending packet with data length: " + Data.Length);
+                    Pack.AppendData(Data);
+                    Server.Send(Pack);
+                    Log.Output(Log.Severity.INFO, Log.Source.GUI, "Sending custom packet: " + Pack.ToString());
+                }
             }
             catch(Exception Exc)
             {
@@ -140,8 +143,11 @@ namespace Science_Base
 
         public void UpdateClientList(object Sender, EventArgs Event)
         {
-            this.ClientSelector.Items.Clear();
-            this.ClientSelector.Items.AddRange(Server.GetClients().ToArray());
+            Invoke((MethodInvoker)delegate
+            {
+                this.ClientSelector.Items.Clear();
+                this.ClientSelector.Items.AddRange(Server.GetClients().ToArray());
+            });
         }
     }
 }

--- a/Science/Science Onboard/RoverMain.cs
+++ b/Science/Science Onboard/RoverMain.cs
@@ -35,11 +35,17 @@ namespace Science
             Log.Begin();
             Log.ForceOutput(Log.Severity.INFO, Log.Source.OTHER, "Science Station - Rover Side");
 
-            Client.Start(IP, PortTCP, PortUDP, "TestClient");
-            Packet TestPacket = new Packet(0x30, false);
-            TestPacket.AppendData(new byte[] { 0xC3 });
-            Client.SendNow(TestPacket);
+            RaspberryPi.Initialize();
+            RPiTests.TestI2C();
 
+            // Test Low Pass Filter Response
+            IFilter<double> AverageTest = new Average<double>(5);
+            
+            for(int i = 1; i <= 16; i++)
+            {
+                AverageTest.Feed(i*i);
+            }
+            
             while (Console.KeyAvailable) { Console.ReadKey(); }
             Log.ForceOutput(Log.Severity.INFO, Log.Source.OTHER, "Press any key to exit.");
             Console.ReadKey();

--- a/Science/Science Onboard/RoverMain.cs
+++ b/Science/Science Onboard/RoverMain.cs
@@ -35,14 +35,11 @@ namespace Science
             Log.Begin();
             Log.ForceOutput(Log.Severity.INFO, Log.Source.OTHER, "Science Station - Rover Side");
 
-            // Test Low Pass Filter Response
-            IFilter<double> AverageTest = new Average<double>(5);
-            
-            for(int i = 1; i <= 16; i++)
-            {
-                AverageTest.Feed(i*i);
-            }
-            
+            Client.Start("192.168.1.13", 10765, 11765, "TestClient");
+            Packet TestPacket = new Packet(0x30, false);
+            TestPacket.AppendData(new byte[] { 0xC3 });
+            Client.SendNow(TestPacket);
+
             while (Console.KeyAvailable) { Console.ReadKey(); }
             Log.ForceOutput(Log.Severity.INFO, Log.Source.OTHER, "Press any key to exit.");
             Console.ReadKey();

--- a/Science/Science Onboard/RoverMain.cs
+++ b/Science/Science Onboard/RoverMain.cs
@@ -35,7 +35,7 @@ namespace Science
             Log.Begin();
             Log.ForceOutput(Log.Severity.INFO, Log.Source.OTHER, "Science Station - Rover Side");
 
-            Client.Start("192.168.1.13", 10765, 11765, "TestClient");
+            Client.Start(IP, PortTCP, PortUDP, "TestClient");
             Packet TestPacket = new Packet(0x30, false);
             TestPacket.AppendData(new byte[] { 0xC3 });
             Client.SendNow(TestPacket);

--- a/Shared/Scarlet/Communications/Client.cs
+++ b/Shared/Scarlet/Communications/Client.cs
@@ -227,10 +227,7 @@ namespace Scarlet.Communications
         /// handling connection retries
         /// </summary>
         /// <returns></returns>
-        private static Thread RetryConnectionThreadFactory()
-        {
-            return new Thread(new ThreadStart(RetryConnecting));
-        }
+        private static Thread RetryConnectionThreadFactory() { return new Thread(new ThreadStart(RetryConnecting)); }
 
         #endregion
 
@@ -249,12 +246,13 @@ namespace Scarlet.Communications
             // While we need to continue receiving
             while (!StopProcesses)
             {
+                // Sleep for the operation period
+                Thread.Sleep(OperationPeriod);
+
                 // Checks if the client is connected and if
                 // the server has available data
-
                 if (Socket.Available > 0)
                 {
-                    Thread.Sleep(OperationPeriod);
                     // Buffer for the newly received data
                     byte[] ReceiveBuffer = new byte[ReceiveBufferSize];
                     try
@@ -294,6 +292,8 @@ namespace Scarlet.Communications
             // While we need to continue the processing
             while (!StopProcesses)
             {
+                // Sleep for the operation period
+                Thread.Sleep(OperationPeriod);
                 // Whether or not there are packets in the queue
                 bool HasPackets;
                 // Determines the length of the queue
@@ -344,6 +344,8 @@ namespace Scarlet.Communications
         /// <returns>Success of packet sending.</returns>
         public static bool SendNow(Packet SendPacket)
         {
+            // Sleep for the operation period
+            Thread.Sleep(OperationPeriod);
             // Check initialization status of Client
             if (!Initialized) { throw new InvalidOperationException("Cannot use client before initialization. Call Client.Start();"); }
             // Checks the connection status of client
@@ -420,7 +422,11 @@ namespace Scarlet.Communications
                         }
                     }
                     lock (SendQueue) { SendQueue.Dequeue(); }
+
                 }
+
+                // Sleep for the operation period
+                Thread.Sleep(OperationPeriod);
             }
         }
 

--- a/Shared/Scarlet/Communications/Client.cs
+++ b/Shared/Scarlet/Communications/Client.cs
@@ -30,6 +30,7 @@ namespace Scarlet.Communications
         public static List<Packet> PacketsSent { get; private set; }
         public static string Name { get; private set; }
         public static bool IsConnected { get; private set; }
+        public static bool OutputWatchdogDebug = false;
 
         /// <summary>
         /// Starts a Client process.
@@ -192,7 +193,9 @@ namespace Scarlet.Communications
                         Log.Output(Log.Severity.DEBUG, Log.Source.NETWORK, "Receiving from socket...");
                         int Size = ReceiveFrom.Receive(ReceiveBuffer);
                         Packet Received = new Packet(new Message(ReceiveBuffer.Take(Size).ToArray()), ReceiveFrom.ProtocolType == ProtocolType.Udp);
-                        Log.Output(Log.Severity.DEBUG, Log.Source.NETWORK, "Received: " + Received.ToString());
+                        bool Output = true;
+                        if (Received.Data.ID == Constants.WATCHDOG_PING) { Output = OutputWatchdogDebug; }
+                        if (Output) { Log.Output(Log.Severity.DEBUG, Log.Source.NETWORK, "Received: " + Received.ToString()); }
                         if (StorePackets) { PacketsReceived.Add(Received); }
                         lock (ReceiveQueue) { ReceiveQueue.Enqueue(Received); }
                         Thread.Sleep(OperationPeriod);

--- a/Shared/Scarlet/Communications/Client.cs
+++ b/Shared/Scarlet/Communications/Client.cs
@@ -13,6 +13,8 @@ namespace Scarlet.Communications
     public static class Client
     {
 
+        public static string Name;
+
         /// <summary>
         /// Starts a Client process.
         /// </summary>

--- a/Shared/Scarlet/Communications/Client.cs
+++ b/Shared/Scarlet/Communications/Client.cs
@@ -81,7 +81,7 @@ namespace Scarlet.Communications
                 // Initialize (but do not start the threads)
                 SendThread = new Thread(new ThreadStart(SendPackets));
                 ProcessThread = new Thread(new ThreadStart(ProcessPackets));
-                RetryConnection = RetyConnectionThreadFactory();
+                RetryConnection = RetryConnectionThreadFactory();
                 ReceiveThreadTCP = new Thread(new ParameterizedThreadStart(ReceiveFromSocket));
                 ReceiveThreadUDP = new Thread(new ParameterizedThreadStart(ReceiveFromSocket));
 
@@ -140,7 +140,7 @@ namespace Scarlet.Communications
             if (IsConnected && RetryConnection.IsAlive) { RetryConnection.Join(); }
             else if (!IsConnected)
             {
-                RetryConnection = RetyConnectionThreadFactory();
+                RetryConnection = RetryConnectionThreadFactory();
                 RetryConnection.Start();
                 Log.Output(Log.Severity.ERROR, Log.Source.NETWORK, "Disconnected from server... Retrying...");
             }
@@ -227,7 +227,7 @@ namespace Scarlet.Communications
         /// handling connection retries
         /// </summary>
         /// <returns></returns>
-        private static Thread RetyConnectionThreadFactory()
+        private static Thread RetryConnectionThreadFactory()
         {
             return new Thread(new ThreadStart(RetryConnecting));
         }

--- a/Shared/Scarlet/Communications/Client.cs
+++ b/Shared/Scarlet/Communications/Client.cs
@@ -7,6 +7,7 @@ using System.Net.Sockets;
 using System.Threading;
 using System.IO;
 using System.Collections;
+using System.Diagnostics;
 
 namespace Scarlet.Communications
 {
@@ -373,8 +374,8 @@ namespace Scarlet.Communications
         }
 
         /// <summary>
-        /// Assumes IsConnected is true,
-        /// sends a packet to the Server UDP
+        /// Assumes IsConnected is true.
+        /// Sends a packet to the Server UDP
         /// port.
         /// </summary>
         /// <param name="UDPPacket">The Packet to send via UDP</param>
@@ -390,8 +391,8 @@ namespace Scarlet.Communications
         }
 
         /// <summary>
-        /// Assumes IsConnected is true,
-        /// sends a packet to the Server TCP
+        /// Assumes IsConnected is true.
+        /// Sends a packet to the Server TCP
         /// port.
         /// </summary>
         /// <param name="TCPPacket">The Packet to send via TCP</param>
@@ -430,9 +431,16 @@ namespace Scarlet.Communications
                 if (HasPackets)
                 {
                     Packet ToSend; // Packet for sending
-                    lock (SendQueue) { ToSend = (Packet)(SendQueue.Peek().Clone()); }
-                    // Ensure that the endpoint to send to is not null
-                    ToSend.Endpoint = ToSend.Endpoint ?? "Server";
+                    // Ensures that the packet has a non-null endpoint before clone
+                    lock (SendQueue)
+                    {
+                        // Temporarily store the object in ToSend
+                        ToSend = SendQueue.Peek();
+                        // Check that the packet endpoint is not null, set to "Server" otherwise
+                        ToSend.Endpoint = ToSend.Endpoint ?? "Server";
+                        // Clone the packet so that we do not change the fields of the given packet (other than the Endpoint)
+                        ToSend = (Packet)ToSend.Clone();
+                    }
                     try
                     {
                         SendNow(ToSend); // Try to send the packet
@@ -521,6 +529,7 @@ namespace Scarlet.Communications
         /// </summary>
         /// <returns>The length of the send queue</returns>
         public static int GetSendQueueCount() { return SendQueue.Count; }
+
         #endregion
 
     }

--- a/Shared/Scarlet/Communications/Client.cs
+++ b/Shared/Scarlet/Communications/Client.cs
@@ -12,25 +12,6 @@ namespace Scarlet.Communications
 
     public static class Client
     {
-        private static TcpClient ClientTCP;
-        private static UdpClient ClientUDP;
-        private static Thread SendThread;
-        private static Thread ReceiveThreadTCP;
-        private static Thread ReceiveThreadUDP;
-        private static Thread ProcessThread;
-        private static Queue<Packet> SendQueue, ReceiveQueue;
-        private static IPEndPoint EndpointUDP, EndpointTCP;
-        private static bool Initialized, HasConnected, Stopping;
-        private static int ReceiveBufferSize, OperationPeriod;
-        private const int TIMEOUT = 5000; // In ms
-        private const int RECONNECT_DELAY_TIMEOUT = 500; // In ms
-
-        public static bool StorePackets;
-        public static List<Packet> PacketsReceived { get; private set; }
-        public static List<Packet> PacketsSent { get; private set; }
-        public static string Name { get; private set; }
-        public static bool IsConnected { get; private set; }
-        public static bool OutputWatchdogDebug = false;
 
         /// <summary>
         /// Starts a Client process.
@@ -42,191 +23,10 @@ namespace Scarlet.Communications
         /// <param name="OperationPeriod">Time in between receiving and sending individual packets.</param>
         public static void Start(string ServerIP, int PortTCP, int PortUDP, string Name, int ReceiveBufferSize = 64, int OperationPeriod = 20)
         {
-            Log.Output(Log.Severity.DEBUG, Log.Source.NETWORK, "Initializing Client.");
-            Client.Name = Name;
-            Client.ReceiveBufferSize = ReceiveBufferSize;
-            Client.OperationPeriod = OperationPeriod;
-            IPAddress DestinationIP = IPAddress.Parse(ServerIP);
-            Client.EndpointTCP = new IPEndPoint(DestinationIP, PortTCP);
-            Client.EndpointUDP = new IPEndPoint(DestinationIP, PortUDP);
-            Client.Stopping = false;
-            if (!Initialized)
-            {
-                PacketHandler.Start();
-                WatchdogManager.ConnectionChanged += ChangeConnectionStatus;
-                Client.SendQueue = new Queue<Packet>();
-                Client.ReceiveQueue = new Queue<Packet>();
-                Client.SendThread = new Thread(new ThreadStart(SendPackets));
-                Client.ProcessThread = new Thread(new ThreadStart(ProcessPackets));
-                Client.ReceiveThreadTCP = new Thread(new ParameterizedThreadStart(ReceiveFromSocket));
-                Client.ReceiveThreadUDP = new Thread(new ParameterizedThreadStart(ReceiveFromSocket));
-                Client.ClientTCP = new TcpClient();
-                Client.ClientUDP = new UdpClient();
-            }
-            Log.Output(Log.Severity.DEBUG, Log.Source.NETWORK, "Attempting to connect to Server on Ports " + PortTCP + " (TCP) and " + PortUDP + " (UDP).");
-            Connect();
-            Initialized = true;
+            
         }
-
-        #region Internal
-
-        /// <summary>
-        /// Connects TCP and UDP clients to 
-        /// server. Logs errors if they occur.
-        /// </summary>
-        private static void Connect()
-        {
-            if (HasConnected) { return; }
-            try { ClientTCP.Connect(EndpointTCP); }
-            catch (SocketException Exception)
-            {
-                Log.Output(Log.Severity.ERROR, Log.Source.NETWORK, "Could not connect to TCP Server.");
-                Log.Exception(Log.Source.NETWORK, Exception);
-                Reconnect();
-                return;
-            }
-            try { ClientUDP.Connect(EndpointUDP); }
-            catch (SocketException Exception)
-            {
-                Log.Output(Log.Severity.ERROR, Log.Source.NETWORK, "Could not connect to UDP Server.");
-                Log.Exception(Log.Source.NETWORK, Exception);
-                Reconnect();
-                return;
-            }
-            Log.Output(Log.Severity.INFO, Log.Source.NETWORK, "TCP and UDP Clients Connected to Server. UDP Port " + EndpointUDP.Port.ToString() + " and TCP Port " + EndpointTCP.Port.ToString());
-            Reconnect();
-            IsConnected = true;
-            ClientTCP.Client.SendTimeout = TIMEOUT; // Set send timeout for TCP Client
-        }
-
-        /// <summary>
-        /// Sends the name of the client to the 
-        /// server.
-        /// </summary>
-        private static void SendName()
-        {
-            byte[] Bytes = UtilData.ToBytes(Name);
-            ClientTCP.Client.Send(Bytes);
-            ClientUDP.Client.Send(Bytes);
-        }
-
-        /// <summary>
-        /// Blocks until reconnect found
-        /// </summary>
-        private static void ListenForReconnect()
-        {
-            Stopping = true;
-            bool ConnectionFound = false;
-            Log.Output(Log.Severity.DEBUG, Log.Source.NETWORK, "Listening for connection...");
-            while (!ConnectionFound)
-            {
-                try
-                {
-                    SendName();
-                    Log.Output(Log.Severity.DEBUG, Log.Source.NETWORK, "Connection found...");
-                    ConnectionFound = true;
-                }
-                catch { Thread.Sleep(RECONNECT_DELAY_TIMEOUT); }
-            }
-            Stopping = false;
-            HasConnected = true;
-            Restart();
-        }
-
-        /// <summary>Starts a thread to reconnect the Server and Client</summary>
-        private static void Reconnect() { new Thread(new ThreadStart(ListenForReconnect)).Start(); }
-        /// <summary>Starts all primary threads.</summary>
-        private static void Restart() { new Thread(new ThreadStart(StartThreads)).Start(); }
-
-        /// <summary>
-        /// Starts all primary threads.
-        /// </summary>
-        private static void StartThreads()
-        {
-            SendThread.Start();
-            ReceiveThreadTCP.Start(ClientTCP.Client);
-            ReceiveThreadUDP.Start(ClientUDP.Client);
-            ProcessThread.Start();
-            SendThread.Join();
-            ReceiveThreadTCP.Join();
-            ReceiveThreadUDP.Join();
-            ProcessThread.Join();
-            Initialized = false;
-        }
-
-        /// <summary>
-        /// Happens when watchdog timer sees a connection change.
-        /// </summary>
-        /// <param name="Sender">Event sender parameter, usually "Watchdog Timer" in this case.</param>
-        /// <param name="Event">The event passed to the handler.</param>
-        private static void ChangeConnectionStatus(object Sender, ConnectionStatusChanged Event)
-        {
-            IsConnected = Event.StatusConnected;
-            if (!Event.StatusConnected)
-            {
-                Log.Output(Log.Severity.WARNING, Log.Source.NETWORK, "Server was disconnected or interuppted, stopping all transmissions and attempting to reconnect...");
-                Reconnect();
-            }
-            else { Log.Output(Log.Severity.WARNING, Log.Source.NETWORK, "Server (re)connected..."); }
-        }
-
-        #endregion
 
         #region Receive
-
-        /// <summary>
-        /// Continuously receives from socket, until 
-        /// Client.Stopping is true. Automatically distributes
-        /// incoming messages to approprate locations.
-        /// </summary>
-        /// <param name="Socket">Socket to receive on. Must be of type Socket</param>
-        private static void ReceiveFromSocket(object Socket)
-        {
-            Socket ReceiveFrom = (Socket)Socket;
-            while (!Stopping)
-            {
-                if (ReceiveFrom.Available > 0 && ClientTCP.Connected)
-                {
-                    byte[] ReceiveBuffer = new byte[ReceiveBufferSize];
-                    try
-                    {
-                        Log.Output(Log.Severity.DEBUG, Log.Source.NETWORK, "Receiving from socket...");
-                        int Size = ReceiveFrom.Receive(ReceiveBuffer);
-                        Packet Received = new Packet(new Message(ReceiveBuffer.Take(Size).ToArray()), ReceiveFrom.ProtocolType == ProtocolType.Udp);
-                        bool Output = true;
-                        if (Received.Data.ID == Constants.WATCHDOG_PING) { Output = OutputWatchdogDebug; }
-                        if (Output) { Log.Output(Log.Severity.DEBUG, Log.Source.NETWORK, "Received: " + Received.ToString()); }
-                        if (StorePackets) { PacketsReceived.Add(Received); }
-                        lock (ReceiveQueue) { ReceiveQueue.Enqueue(Received); }
-                        Thread.Sleep(OperationPeriod);
-                    }
-                    catch (SocketException Exception)
-                    {
-                        Log.Output(Log.Severity.ERROR, Log.Source.NETWORK, "Failed to receive from socket. Check connection status.");
-                        Log.Exception(Log.Source.NETWORK, Exception);
-                    }
-                }
-            }
-        }
-
-        /// <summary>
-        /// Handles packets as they are received
-        /// from server.
-        /// </summary>
-        private static void ProcessPackets()
-        {
-            while (!Stopping)
-            {
-                bool HasPackets = false;
-                lock (ReceiveQueue) { HasPackets = ReceiveQueue.Count != 0; }
-                if (HasPackets)
-                {
-                    Packet Processing;
-                    lock (ReceiveQueue) { Processing = ReceiveQueue.Dequeue(); }
-                    Parse.ParseMessage(Processing);
-                }
-            }
-        }
 
         #endregion
 
@@ -239,12 +39,7 @@ namespace Scarlet.Communications
         /// <returns>Success of packet sending</returns>
         public static bool Send(Packet SendPacket)
         {
-            if (!Initialized) { throw new InvalidOperationException("Cannot use Client before initialization. Call Client.Start()."); }
-            if (!Stopping)
-            {
-                if (SendPacket.IsUDP) { return SendNow(SendPacket); }
-                lock (SendQueue) { SendQueue.Enqueue(SendPacket); }
-            }
+
             return true;
         }
 
@@ -256,106 +51,9 @@ namespace Scarlet.Communications
         /// <returns>Success of packet sending.</returns>
         public static bool SendNow(Packet SendPacket)
         {
-            if (SendPacket.Endpoint == null) { SendPacket.Endpoint = "Server"; }
-            if (!Stopping)
-            {
-                if (!Initialized) { throw new InvalidOperationException("Cannot use Client before initialization. Call Client.Start()."); }
-                if (SendPacket.IsUDP)
-                {
-                    int BytesSent = 0;
-                    try
-                    {
-                        lock (ClientUDP) { BytesSent = ClientUDP.Send(SendPacket.GetForSend(), SendPacket.GetForSend().Length); }
-                    }
-                    catch (SocketException Exception)
-                    {
-                        Log.Output(Log.Severity.ERROR, Log.Source.NETWORK, "An error occurred when accessing the socket. Check connection status.");
-                        Log.Exception(Log.Source.NETWORK, Exception);
-                        return false;
-                    }
-                    catch (ObjectDisposedException Exception)
-                    {
-                        Log.Output(Log.Severity.ERROR, Log.Source.NETWORK, "Client UDP socket stream is closed. Consider restart, check connection status.");
-                        Log.Exception(Log.Source.NETWORK, Exception);
-                        return false;
-                    }
-                    Thread.Sleep(OperationPeriod);
-                    if (BytesSent != 0 && StorePackets) { PacketsSent.Add(SendPacket); }
-                    return true;
-                }
-                else
-                { // Use TCP
-                    if (!ClientTCP.Connected)
-                    {
-                        Log.Output(Log.Severity.ERROR, Log.Source.NETWORK, "Attemping to send TCP packet without TCP server connection. Check connection status.");
-                        return false;
-                    }
-                    else
-                    {
-                        try
-                        {
-                            lock (ClientTCP)
-                            {
-                                ClientTCP.GetStream().Write(SendPacket.GetForSend(), 0, SendPacket.GetForSend().Length);
-                            }
-                        }
-                        catch (IOException Exception)
-                        {
-                            Log.Output(Log.Severity.ERROR, Log.Source.NETWORK, "Failed to write to socket stream. Check connection status.");
-                            Log.Exception(Log.Source.NETWORK, Exception);
-                            return false;
-                        }
-                        catch (ObjectDisposedException Exception)
-                        {
-                            Log.Output(Log.Severity.ERROR, Log.Source.NETWORK, "Client TCP socket stream is closed. Consider restart, check connection status.");
-                            Log.Exception(Log.Source.NETWORK, Exception);
-                            return false;
-                        }
-                        if (StorePackets) { PacketsSent.Add(SendPacket); }
-                        Thread.Sleep(OperationPeriod);
-                    }
-                    return true;
-                }
-            }
             return false;
         }
-
-        /// <summary>
-        /// Iteratively sends packets that 
-        /// are in the send queue. Blocks
-        /// while Client is running.
-        /// </summary>
-        private static void SendPackets()
-        {
-            while (!Stopping)
-            {
-                bool HasPacket;
-                lock (SendQueue) { HasPacket = SendQueue.Count > 0; }
-                if (HasPacket)
-                {
-                    Packet ToSend;
-                    lock (SendQueue) { ToSend = (Packet)(SendQueue.Peek().Clone()); }
-                    try
-                    {
-                        SendNow(ToSend);
-                        lock (SendQueue) { SendQueue.Dequeue(); } // Remove the packet from the queue when it has been sent sucessfully.
-                    }
-                    catch (Exception Exc)
-                    {
-                        Log.Output(Log.Severity.WARNING, Log.Source.NETWORK, "Failed to send packet.");
-                        Log.Exception(Log.Source.NETWORK, Exc);
-                    }
-                }
-                Thread.Sleep(OperationPeriod);
-            }
-        }
-
         #endregion
-
-        #region Info
-        public static int GetReceiveQueueLength() { return ReceiveQueue.Count; }
-        public static int GetSendQueueLength() { return SendQueue.Count; }
-        #endregion
-
+        
     }
 }

--- a/Shared/Scarlet/Communications/Packet.cs
+++ b/Shared/Scarlet/Communications/Packet.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Net;
 using Scarlet.Utilities;
+using System.Net.Sockets;
+using System.Linq;
 
 namespace Scarlet.Communications
 {
@@ -86,6 +88,19 @@ namespace Scarlet.Communications
             Clone.Data = this.Data != null ? (Message)this.Data.Clone() : null;
             Clone.Endpoint = string.Copy(this.Endpoint);
             return Clone;
+        }
+
+        /// <summary>
+        /// Returns a packet from given bytes and
+        /// a protocol type for the packet.
+        /// </summary>
+        /// <param name="PacketBytes">Raw bytes of packet data.</param>
+        /// <param name="Protocol">Protocol</param>
+        /// <returns></returns>
+        internal static Packet FromBytes(byte[] PacketBytes, ProtocolType Protocol)
+        {
+            // Construct a new packet given the incoming bytes and return it
+            return new Packet(new Message(PacketBytes), Protocol == ProtocolType.Udp);
         }
     }
 }

--- a/Shared/Scarlet/Communications/Server.cs
+++ b/Shared/Scarlet/Communications/Server.cs
@@ -449,6 +449,7 @@ namespace Scarlet.Communications
             }
             if (!Clients.ContainsKey(ToSend.Endpoint))
             {
+                WatchdogManager.RemoveWatchdog(ToSend.Endpoint);
                 Log.Output(Log.Severity.WARNING, Log.Source.NETWORK, "Tried to send packet to unknown client. Dropping.");
                 return;
             }

--- a/Shared/Scarlet/Communications/Server.cs
+++ b/Shared/Scarlet/Communications/Server.cs
@@ -266,7 +266,6 @@ namespace Scarlet.Communications
                 Listener = (UdpClient)Result.AsyncState;
                 ReceivedEndpoint = new IPEndPoint(IPAddress.Any, 0);
                 Data = Listener.EndReceive(Result, ref ReceivedEndpoint);
-                Log.Output(Log.Severity.DEBUG, Log.Source.NETWORK, "Received data from client (UDP).");
                 ClientName = FindClient(ReceivedEndpoint, true);
             }
             catch(Exception Exc)
@@ -318,13 +317,6 @@ namespace Scarlet.Communications
                 }
                 else // Existing client
                 {
-                    bool Output = true;
-                    try
-                    {
-                        if (Data[5] == Constants.WATCHDOG_PING) { Output = OutputWatchdogDebug; }
-                    }
-                    catch { }
-                    if (Output) { Log.Output(Log.Severity.DEBUG, Log.Source.NETWORK, "Received data from client (UDP)."); }
                     Packet ReceivedPack = new Packet(new Message(Data), false, ClientName);
                     lock (ReceiveQueue) { ReceiveQueue.Enqueue(ReceivedPack); }
                     if (StorePackets) { PacketsReceived.Add(ReceivedPack); }

--- a/Shared/Scarlet/Communications/Server.cs
+++ b/Shared/Scarlet/Communications/Server.cs
@@ -149,7 +149,18 @@ namespace Scarlet.Communications
                 }
                 else
                 {
-                    ClientName = UtilData.ToString(DataBuffer.Take(DataSize).ToArray());
+                    ClientName = null;
+                    try
+                    {
+                        ClientName = UtilData.ToString(DataBuffer.Take(DataSize).ToArray());
+                    }
+                    catch
+                    {
+                        if (DataBuffer.Length < 5 || (DataBuffer.Length >= 5 && DataBuffer[4] != Constants.WATCHDOG_PING))
+                        {
+                            Log.Output(Log.Severity.ERROR, Log.Source.NETWORK, "Unknown Packet from unknown client initialization...");
+                        }
+                    }
                     if (ClientName != null && ClientName.Length > 0)
                     {
                         Log.Output(Log.Severity.INFO, Log.Source.NETWORK, "TCP Client connected with name \"" + ClientName + "\".");
@@ -169,6 +180,7 @@ namespace Scarlet.Communications
                                     Connected = true
                                 };
                                 Clients.Add(ClientName, NewClient);
+                                WatchdogManager.AddWatchdog(ClientName);
                             }
                         }
                         lock (SendQueues)
@@ -286,7 +298,18 @@ namespace Scarlet.Communications
             {
                 if (ClientName == null) // New client
                 {
-                    ClientName = UtilData.ToString(Data);
+                    ClientName = null;
+                    try
+                    {
+                        ClientName = UtilData.ToString(Data);
+                    }
+                    catch
+                    {
+                        if (Data.Length < 5 || (Data.Length >= 5 && Data[4] != Constants.WATCHDOG_PING))
+                        {
+                            Log.Output(Log.Severity.ERROR, Log.Source.NETWORK, "Unknown Packet from unknown client initialization...");
+                        }
+                    }
                     if (ClientName != null && ClientName.Length > 0)
                     {
                         Log.Output(Log.Severity.INFO, Log.Source.NETWORK, "UDP Client connected with name \"" + ClientName + "\".");

--- a/Shared/Scarlet/Communications/Server.cs
+++ b/Shared/Scarlet/Communications/Server.cs
@@ -321,7 +321,7 @@ namespace Scarlet.Communications
                     bool Output = true;
                     try
                     {
-                        if (Data[5] == Constants.WATCHDOG_PING) { Output = false; }
+                        if (Data[5] == Constants.WATCHDOG_PING) { Output = OutputWatchdogDebug; }
                     }
                     catch { }
                     if (Output) { Log.Output(Log.Severity.DEBUG, Log.Source.NETWORK, "Received data from client (UDP)."); }

--- a/Shared/Scarlet/Communications/Server.cs
+++ b/Shared/Scarlet/Communications/Server.cs
@@ -150,17 +150,7 @@ namespace Scarlet.Communications
                 else
                 {
                     ClientName = null;
-                    try
-                    {
-                        ClientName = UtilData.ToString(DataBuffer.Take(DataSize).ToArray());
-                    }
-                    catch
-                    {
-                        if (DataBuffer.Length < 5 || (DataBuffer.Length >= 5 && DataBuffer[4] != Constants.WATCHDOG_PING))
-                        {
-                            Log.Output(Log.Severity.ERROR, Log.Source.NETWORK, "Unknown Packet from unknown client initialization...");
-                        }
-                    }
+                    try { ClientName = UtilData.ToString(DataBuffer.Take(DataSize).ToArray()); } catch { }
                     if (ClientName != null && ClientName.Length > 0)
                     {
                         Log.Output(Log.Severity.INFO, Log.Source.NETWORK, "TCP Client connected with name \"" + ClientName + "\".");
@@ -180,7 +170,6 @@ namespace Scarlet.Communications
                                     Connected = true
                                 };
                                 Clients.Add(ClientName, NewClient);
-                                WatchdogManager.AddWatchdog(ClientName);
                             }
                         }
                         lock (SendQueues)
@@ -298,18 +287,7 @@ namespace Scarlet.Communications
             {
                 if (ClientName == null) // New client
                 {
-                    ClientName = null;
-                    try
-                    {
-                        ClientName = UtilData.ToString(Data);
-                    }
-                    catch
-                    {
-                        if (Data.Length < 5 || (Data.Length >= 5 && Data[4] != Constants.WATCHDOG_PING))
-                        {
-                            Log.Output(Log.Severity.ERROR, Log.Source.NETWORK, "Unknown Packet from unknown client initialization...");
-                        }
-                    }
+                    try { ClientName = UtilData.ToString(Data); } catch { }
                     if (ClientName != null && ClientName.Length > 0)
                     {
                         Log.Output(Log.Severity.INFO, Log.Source.NETWORK, "UDP Client connected with name \"" + ClientName + "\".");

--- a/Shared/Scarlet/Communications/Server.cs
+++ b/Shared/Scarlet/Communications/Server.cs
@@ -451,7 +451,10 @@ namespace Scarlet.Communications
         public static void SendNow(Packet ToSend)
         {
             if (!Initialized) { throw new InvalidOperationException("Cannot use Server before initialization. Call Server.Start()."); }
-            Log.Output(Log.Severity.DEBUG, Log.Source.NETWORK, "Sending packet: " + ToSend);
+            if (ToSend.Data.ID != Constants.WATCHDOG_PING || OutputWatchdogDebug)
+            {
+                Log.Output(Log.Severity.DEBUG, Log.Source.NETWORK, "Sending packet: " + ToSend);
+            }
             if (!Clients.ContainsKey(ToSend.Endpoint))
             {
                 Log.Output(Log.Severity.WARNING, Log.Source.NETWORK, "Tried to send packet to unknown client. Dropping.");

--- a/Shared/Scarlet/Communications/WatchdogManager.cs
+++ b/Shared/Scarlet/Communications/WatchdogManager.cs
@@ -108,9 +108,9 @@ namespace Scarlet.Communications
         /// <summary>
         /// Adds a watchdog endpoint.
         /// Useful for servers, cannot use with Client Watchdogs. 
-        /// Add client endpoint, 
+        /// Creates a new Watchdog for send-receive
         /// </summary>
-        /// <param name="Endpoint"></param>
+        /// <param name="Endpoint">The endpoint to add</param>
         internal static void AddWatchdog(string Endpoint)
         {
             // Check if a client attempts to add a watchdog

--- a/Shared/Scarlet/Communications/WatchdogManager.cs
+++ b/Shared/Scarlet/Communications/WatchdogManager.cs
@@ -66,6 +66,7 @@ namespace Scarlet.Communications
             if (!Watchdogs.ContainsKey(Endpoint))
             {
                 Watchdogs.Add(Endpoint, new Watchdog(Endpoint, false));
+                WatchdogKeys.Add(Endpoint);
             }
         }
 

--- a/Shared/Scarlet/Communications/WatchdogManager.cs
+++ b/Shared/Scarlet/Communications/WatchdogManager.cs
@@ -41,7 +41,7 @@ namespace Scarlet.Communications
             {
                 WatchdogPacket.UpdateTimestamp();
                 Thread.Sleep(Constants.WATCHDOG_INTERVAL);
-                if (IsClient) { Client.SendNow(WatchdogPacket); }
+                if (IsClient) { Client.SendRegardless(WatchdogPacket); }
                 else
                 {
                     foreach (string EP in Watchdogs.Keys)
@@ -63,7 +63,7 @@ namespace Scarlet.Communications
 
         public static void FoundWatchdog(string Endpoint)
         {
-            if (!Started) { Start(true, Client.Name); }
+            if (!Started && Endpoint == "Server") { Start(true, Client.Name); }
             Watchdogs[Endpoint].FoundWatchdog();
         }
 

--- a/Shared/Scarlet/Communications/WatchdogManager.cs
+++ b/Shared/Scarlet/Communications/WatchdogManager.cs
@@ -5,49 +5,96 @@ using System.Text;
 
 namespace Scarlet.Communications
 {
-    static class WatchdogManager
+    /// <summary>
+    /// WatchdogManager handles internal
+    /// watchdog receiving and sending for
+    /// both Clients and Servers. Not meant
+    /// for End-User. Is internal to Scarlet.
+    /// For more information about watchdogs,
+    /// visit the OneNote documentation.
+    /// * All watchdogs are send with UDP
+    /// </summary>
+    internal static class WatchdogManager
     {
+        // Define booleans for whether or not the manager is a client manager and whether or not it is started.
         private static bool IsClient, Started;
+        // Define the continue state for continuous looping of the watchdog threads
         private static bool Continue = true;
+        // The name of the watchdog sender
         private static string MyName;
+        // The watchdog packet to send iteratively
         private static Packet WatchdogPacket;
+        // A dictionary of watchdog endpoints
         private static Dictionary<string, Watchdog> Watchdogs;
+        // A list of the watchdogs (to avoid multi-thread editing) 
+        // TODO: Find a better solution than a new List
         private static List<string> WatchdogKeys;
-        public static event EventHandler<ConnectionStatusChanged> ConnectionChanged;
+        // The event to fire when a connection has changed
+        internal static event EventHandler<ConnectionStatusChanged> ConnectionChanged;
 
-        public static void Start(bool IsClient = false, string MyName = "Server")
+        /// <summary>
+        /// Starts a watchdog manager.
+        /// Parameters default to a server
+        /// watchdog. If you are a server you
+        /// can just call WatchdogManager.Start()
+        /// Will not change any functionality unless 
+        /// WatchdogManager is in a stopped state
+        /// </summary>
+        /// <param name="IsClient">Whether or not the watchdog sender is a client</param>
+        /// <param name="MyName">The name of the watchdog sender</param>
+        internal static void Start(bool IsClient = false, string MyName = "Server")
         {
+            // As long as the watchdog is not already started, go ahead with initialization.
             if (!Started)
             {
+                // Set internal fields to given parameters
                 WatchdogManager.MyName = MyName;
                 WatchdogManager.IsClient = IsClient;
+                // Initialize data structures
                 WatchdogManager.Watchdogs = new Dictionary<string, Watchdog>();
+                WatchdogManager.WatchdogKeys = new List<string>();
+                // Construct the watchdog packet (UDP)
                 WatchdogManager.WatchdogPacket = new Packet(Constants.WATCHDOG_PING, true);
                 WatchdogManager.WatchdogPacket.AppendData(Utilities.UtilData.ToBytes(MyName));
-                WatchdogManager.WatchdogKeys = new List<string>();
-                if (IsClient) { Watchdogs.Add("Server", new Watchdog("Server", true)); WatchdogKeys.Add("Server"); }
+                // If Watchdog sender is a client, solely add the server to the watchdogs
+                if (IsClient) { Watchdogs.Add("Server", new Watchdog("Server")); WatchdogKeys.Add("Server"); }
+                // Start the send thread
                 new Thread(new ThreadStart(Send)).Start();
+                // Set the state of WatchdogManager to be started
                 Started = true;
             }
         }
 
-        public static void Stop()
+        /// <summary>
+        /// Stops the watchdog. Call Start(...) again to restart the watchdog process
+        /// </summary>
+        internal static void Stop()
         {
             Continue = false;
             Started = false;
         }
 
-        public static void Send()
+        /// <summary>
+        /// Sends all required watchdogs over the network.
+        /// </summary>
+        private static void Send()
         {
+            // While the continue state of watchdog is set
             while (Continue)
             {
+                // Update the timestamp on the packet
                 WatchdogPacket.UpdateTimestamp();
+                // Sleep for a given interval to avoid CPU overload
                 Thread.Sleep(Constants.WATCHDOG_INTERVAL);
-                if (IsClient) { Client.SendNow(WatchdogPacket); }
+                // Send the watchdogs
+                // The client should send watchdogs regardless of whether or not it detects a connection
+                if (IsClient) { Client.SendRegardless(WatchdogPacket); } 
                 else
                 {
+                    // Lock the watchdog keys on this thread
                     lock (WatchdogKeys)
                     {
+                        // Loop over the endpoints and send the watchdogs with the server
                         foreach (string EP in WatchdogKeys.ToArray())
                         {
                             WatchdogPacket.Endpoint = EP;
@@ -58,37 +105,102 @@ namespace Scarlet.Communications
             }
         }
 
-        public static void AddWatchdog(string Endpoint)
+        /// <summary>
+        /// Adds a watchdog endpoint.
+        /// Useful for servers, cannot use with Client Watchdogs. 
+        /// Add client endpoint, 
+        /// </summary>
+        /// <param name="Endpoint"></param>
+        internal static void AddWatchdog(string Endpoint)
         {
+            // Check if a client attempts to add a watchdog
             if (IsClient) { throw new InvalidOperationException("Clients cannot add watchdogs"); }
+            // Construct the client's watchdog packet
             Packet WatchdogPacket = new Packet(Constants.WATCHDOG_PING, true, Endpoint);
             WatchdogPacket.AppendData(Utilities.UtilData.ToBytes(Endpoint));
+            // Append to the dictionary so long as it isn't already there
+            // (otherwise and exception will be thrown)
             if (!Watchdogs.ContainsKey(Endpoint))
             {
-                Watchdogs.Add(Endpoint, new Watchdog(Endpoint, false));
+                Watchdogs.Add(Endpoint, new Watchdog(Endpoint));
                 WatchdogKeys.Add(Endpoint);
             }
         }
 
-        public static void RemoveWatchdog(string Endpoint)
+        /// <summary>
+        /// Removes a watchdog endpoint from the system completely.
+        /// Use only if you are a server
+        /// </summary>
+        /// <param name="Endpoint">The endpoint to remove</param>
+        internal static void RemoveWatchdog(string Endpoint)
         {
+            // Check if a client attempts to remove a watchdog
+            if (IsClient) { throw new InvalidOperationException("Clients cannot remove watchdogs"); }
+            // Remove the watchdogs from the data structures
             lock (Watchdogs) { Watchdogs.Remove(Endpoint); }
             lock (WatchdogKeys) { WatchdogKeys.Remove(Endpoint); }
-            Console.WriteLine(Watchdogs.Keys.ToString());
         }
 
-        public static void FoundWatchdog(string Endpoint)
+        /// <summary>
+        /// Call this if you have found a watchdog.
+        /// If you are client, make sure that the
+        /// Endpoint is "Server".
+        /// This is the basis of the operation,
+        /// when you receive a watchdog packet,
+        /// call this method to invoke a watchdog is found.
+        /// </summary>
+        /// <param name="Endpoint">The endpoint the watchdog was found on</param>
+        internal static void FoundWatchdog(string Endpoint)
         {
+            // If we have not started a watchdog, and we are a client, start it.
             if (!Started) { Start(true, Client.Name); }
+            // Then set the appropriate watchdog to the found state
             Watchdogs[Endpoint].FoundWatchdog();
         }
 
-        public static bool IsConnected() { return Watchdogs["Server"].IsConnected; } // Only for Client
-        public static bool IsConnected(string Endpoint) { return Watchdogs[Endpoint].IsConnected; } // Only for Server
+        /// <summary>
+        /// Checks if there is a connection, only for Client
+        /// </summary>
+        /// <returns>Whether or not there is a server connection</returns>
+        internal static bool IsConnected()
+        {
+            // Check if the system is a server or client. Throw an illegal operation exception if server
+            if (!IsClient) { throw new InvalidOperationException("Cannot call IsConnected without a string parameter if not a client"); }
+            // Typically would check if there is a key "Server" in the dictionary, but there should be if a client
+            // and if there isn't we should throw an exception. This takes care of both scenarios.
+            return Watchdogs["Server"].IsConnected;
+        }
+
+        /// <summary>
+        /// Checks if there is a client connection
+        /// given an endpoint. Only for server
+        /// </summary>
+        /// <param name="Endpoint">Endpoint to check</param>
+        /// <returns>Whether or not there is a watchdog connection with the given endpoint</returns>
+        internal static bool IsConnected(string Endpoint)
+        {
+            // Check if the wrong usage occurs
+            if (IsClient) { throw new InvalidOperationException("Cannot call IsConnected with a string paramter if a client"); }
+            // Check if the data structure contains the endpoint, if not return false
+            if (!Watchdogs.ContainsKey(Endpoint)) { return false; }
+            // Return the connection status of the given endpoint
+            return Watchdogs[Endpoint].IsConnected;
+        }
+
+        /// <summary>
+        /// Invokes a connection change event. Call
+        /// when a connection status changes.
+        /// </summary>
+        /// <param name="Event">The event to trigger</param>
         private static void OnConnectionChange(ConnectionStatusChanged Event) { ConnectionChanged?.Invoke("Watchdog Timer", Event); }
 
+        /// <summary>
+        /// Internal class to the watchdog manager.
+        /// Handles processing of watchdogs
+        /// </summary>
         private class Watchdog
         {
+            // IsConnected determines the connection status of the watchdog
             private bool P_IsConnected;
             public bool IsConnected
             {
@@ -97,30 +209,50 @@ namespace Scarlet.Communications
                 {
                     if (value != P_IsConnected) // Status is changing
                     {
+                        // Trigger the event for connection change
                         ConnectionStatusChanged Event = new ConnectionStatusChanged() { StatusEndpoint = Endpoint, StatusConnected = value };
                         OnConnectionChange(Event);
                     }
-                    P_IsConnected = value;
+                    P_IsConnected = value; // Finally, set the variable
                 }
             }
 
+            // Whether or not a watchdog has been found on the current cycle
             private volatile bool FoundWatchdogThisCycle;
+            // The endpoint of the watchdog receiver (i.e. not the sender)
             private string Endpoint;
 
-            public Watchdog(string ListenFor, bool UseClient)
+            /// <summary>
+            /// Constructs a watchdog object
+            /// </summary>
+            /// <param name="ListenFor">The endpoint to listen for (i.e. not the sender)</param>
+            public Watchdog(string ListenFor)
             {
+                // Set the internal fields and start the listening thread
                 this.Endpoint = ListenFor;
                 new Thread(new ThreadStart(Listen)).Start();
             }
 
-            public void FoundWatchdog() { FoundWatchdogThisCycle = true; }
+            /// <summary>
+            /// Call this on the watchdog if the watchdog was found on the cycle
+            /// </summary>
+            internal void FoundWatchdog() { FoundWatchdogThisCycle = true; }
 
-            public void Listen()
+            /// <summary>
+            /// An interative thread that will stop if 
+            /// WatchdogManager.Stop() is called
+            /// </summary>
+            private void Listen()
             {
+                // While we are not stopping
                 while (Continue)
                 {
+                    // Sleep for a given period to avoid overloading the CPU
                     Thread.Sleep(Constants.WATCHDOG_WAIT);
+                    // Set the IsConnected state to whether or not there was a 
+                    // watchdog found on the cycle.
                     IsConnected = FoundWatchdogThisCycle;
+                    // Reset the found on cycle state of the watchdog
                     FoundWatchdogThisCycle = false;
                 }
             }
@@ -128,9 +260,17 @@ namespace Scarlet.Communications
         }
     }
 
+    /// <summary>
+    /// This class contains the endpoint of the connection,
+    /// and the status of the connection. It overloads EventArgs
+    /// and is used in triggering connection changes between points
+    /// on the communication stream.
+    /// </summary>
     public class ConnectionStatusChanged : EventArgs
     {
+        // The Endpoint that either is or is not connected to the current system
         public string StatusEndpoint;
+        // The status of the endpoints connection with the current system
         public bool StatusConnected;
     }
 


### PR DESCRIPTION
Re-evaluated and made internal changes to (mostly) Client.cs. Now Client passes all send, receive tests, plus (re)connect/disconnect tests. Changes were also made to Packet, WatchdogManager, and Server to fix found bugs and implement internal functionality. End-user interface has not changed.

What has changed:

- Client can now handle startup failure and retrying to connect to the Server
- Client can now handle connection interruptions with server
- Server now handles power cycle while the client runs
- Server now removes the watchdog after loss of client connection
- WatchdogManager now has an internal RemoveWatchdog(), which removes a watchdog timer from an endpoint
- Packet now has a built-in method to create a packet out of raw incoming bytes.